### PR TITLE
shared memory array get and set also taking pointer as arg

### DIFF
--- a/demos/demo_read_array.cpp
+++ b/demos/demo_read_array.cpp
@@ -79,7 +79,7 @@ void run()
 	{
 	  serialized.get(i,item);
 	  fundamental.get(i,value);
-	  fundamental_array.get(i,*values);
+	  fundamental_array.get(i,values);
 	  item.compact_print();
 	  std::cout << " | " << value << " | ";
 	  print_array(values,SIZE);

--- a/demos/demo_write_array.cpp
+++ b/demos/demo_write_array.cpp
@@ -97,7 +97,7 @@ void run()
 	      values[j]=0;
 	    }
 	  values[i]=count;
-	  fundamental_array.set(i,*values);
+	  fundamental_array.set(i,values);
 	  
 	}
       

--- a/include/shared_memory/array.hpp
+++ b/include/shared_memory/array.hpp
@@ -64,7 +64,7 @@ namespace shared_memory
     void init( SERIALIZABLE );
     void set(uint index,const T& t, SERIALIZABLE);
     void get(uint index, T& t, SERIALIZABLE);
-
+    
   public:
 
     /**
@@ -127,10 +127,20 @@ namespace shared_memory
     void set(uint index, const T& t);
 
     /**
+     * @brief set element t at index 
+     */
+    void set(uint index, const T* t);
+    
+    /**
      * @brief read element at index into t
      */
     void get(uint index, T& t);
 
+    /**
+     * @brief read element at index into t
+     */
+    void get(uint index, T* t);
+    
     /**
      * @brief max number of elements in the array
      */

--- a/include/shared_memory/array.hxx
+++ b/include/shared_memory/array.hxx
@@ -88,9 +88,21 @@ void array<T,SIZE>::set(uint index, const T& t)
 }
 
 template<typename T, int SIZE>
+void array<T,SIZE>::set(uint index, const T* t)
+{
+  set(index,*t,this->type_);
+}
+
+template<typename T, int SIZE>
 void array<T,SIZE>::get(uint index, T& t)
 {
   get(index,t,this->type_);
+}
+
+template<typename T, int SIZE>
+void array<T,SIZE>::get(uint index, T* t)
+{
+  get(index,*t,this->type_);
 }
 
 template<typename T, int SIZE>


### PR DESCRIPTION
# Issue solved
The set and get methods of shared_memory::array<T> took only references as argument. This required dereference when T was an array (e.g double[10]). Now set and get can take either reference or pointer

# How it was tested
Demos and unit tests run fine



