### PR TITLE
Export rt and pthread so depending packages have them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,14 @@ include_directories(
 # Declare the libraries to export #
 ###################################
 
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(NON_DARWIN_LIBRARIES rt pthread)
+endif()
+
 catkin_package(
     INCLUDE_DIRS include
     CATKIN_DEPENDS
-    LIBRARIES shared_memory ${protobuf_cmake_target}
+    LIBRARIES shared_memory ${protobuf_cmake_target} ${NON_DARWIN_LIBRARIES}
 )
 
 ###############
@@ -46,13 +50,8 @@ add_library(shared_memory
 target_link_libraries(shared_memory
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${NON_DARWIN_LIBRARIES}
 )
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-target_link_libraries(shared_memory
-  -lrt
-  -pthread
-)
-endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 #########
 # demos #


### PR DESCRIPTION
## Description

Code using the multi-process time series fails with a linker error unless `rt` and `pthread` are explicitly linked to, even if the corresponding code is not using any of them directly (see, for example, the [demos in robot_interfaces](https://github.com/open-dynamic-robot-initiative/robot_interfaces/blob/466a434ae79d54513cb428b6d8c158c76423292c/CMakeLists.txt#L70)).

It seems to me that this is caused by some dependency not exporting their dependency on these libraries correctly.  I tried to trace it down to the lowest level in the dependency tree where these libraries are used which seems to be shared_memory.  Indeed exporting them in the `catkin_package` command removes the need for explicitly linking against them in robot_interfaces.

I'm a bit unsure, though, if this is really the right place to fix this (hence only a draft PR for now).  What is a bit confusing me is that `shared_memory` is already listed in `catkin_package(LIBRARIES ...)` which is linking against `rt` and `pthread`.  I would have assumed that this is enough for depending packages but apparently it is not.


## How I Tested

Just compiled.

## Do not merge before

We agreed that this is the right way to do it.