### PR TITLE
replaced mutex swap by mutex copy in array move operator

### DIFF
--- a/include/shared_memory/array.hxx
+++ b/include/shared_memory/array.hxx
@@ -61,7 +61,7 @@ array<T, SIZE>& array<T, SIZE>::operator=(array<T, SIZE>&& other) noexcept
     other.clear_on_destruction_ = false;
     multiprocess_safe_ = other.multiprocess_safe_;
     init(this->type);
-    std::swap(mutex_, other.mutex_);
+    mutex_ = other.mutex_;
     other.shared_ = nullptr;
     return *this;
 }


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

On ubuntu 18.04 (newer version of compiler compared to 16.04), shared memory mutex can no longer be swapped (no idea why. Compilation error). Replaced the swap by a hard copy.


[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

Ran the unit tests and the demos

