### PR TITLE
fix eigen usage

### DIFF
--- a/.github/workflows/ci_ubuntu_18_04_debug.yml
+++ b/.github/workflows/ci_ubuntu_18_04_debug.yml
@@ -60,5 +60,5 @@ jobs:
           echo Source environment.
           source ${{ steps.clone_and_build_dep.outputs.setup_file }}
           cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DGENERATE_DOCUMENTATION=ON
-          cmake --build . --config $BUILD_TYPE -DGENERATE_DOCUMENTATION=ON
+          cmake --build . --config $BUILD_TYPE
           env CTEST_OUTPUT_ON_FAILURE=1 ctest -C $BUILD_TYPE

--- a/.github/workflows/ci_ubuntu_18_04_release.yml
+++ b/.github/workflows/ci_ubuntu_18_04_release.yml
@@ -60,5 +60,5 @@ jobs:
           echo Source environment.
           source ${{ steps.clone_and_build_dep.outputs.setup_file }}
           cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DGENERATE_DOCUMENTATION=ON
-          cmake --build . --config $BUILD_TYPE -DGENERATE_DOCUMENTATION=ON
+          cmake --build . --config $BUILD_TYPE
           env CTEST_OUTPUT_ON_FAILURE=1 ctest -C $BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${PROJECT_NAME} Boost::boost)
 target_link_libraries(${PROJECT_NAME} cereal::cereal)
 target_link_libraries(${PROJECT_NAME} rt::rt)
 target_link_libraries(${PROJECT_NAME} Threads::Threads)
+target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
 
 # Export the target.
 list(APPEND all_targets ${PROJECT_NAME})

--- a/include/shared_memory/shared_memory.hpp
+++ b/include/shared_memory/shared_memory.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Dense>
 
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/containers/deque.hpp>


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

I am doing this PR because I saw this commit:
https://github.com/machines-in-motion/shared_memory/commit/fb3fd4c43908d932f0f662ab3250b8c466d337b8

CMake is now finding the include using the targets. Hence we need to link against all library even if they are headers only.

The reason why it was working is because the include of Eigen (`#include <eigen3/Eigen/Core>`) was wrong:
- 1/ This is a hard-coded path to the library installed with Debian (not suitable with other installation patterns).
- 2/ This is not the include used in the Eigen tutorials: https://eigen.tuxfamily.org/dox/GettingStarted.html

## How I Tested

[//]: # "Explain how you tested your changes"

I ran tests and built on my machines, and using the CI in github.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
