### PR TITLE
Catch exceptions by const reference

### DIFF
--- a/demos/exchange_manager_producer.cpp
+++ b/demos/exchange_manager_producer.cpp
@@ -82,7 +82,7 @@ void execute()
                               << "\n";
                     c++;
                 }
-                catch (shared_memory::Memory_overflow_exception)
+                catch (const shared_memory::Memory_overflow_exception &)
                 {
                     if (!waiting_warning_printed)
                     {

--- a/demos/non_existing_segment.cpp
+++ b/demos/non_existing_segment.cpp
@@ -27,7 +27,7 @@ int main()
     {
         shared_memory::get<double>(segment_id, segment_id, value, false);
     }
-    catch (shared_memory::Non_existing_segment_exception)
+    catch (const shared_memory::Non_existing_segment_exception &)
     {
     }
 

--- a/src/shared_memory.cpp
+++ b/src/shared_memory.cpp
@@ -59,7 +59,7 @@ bool wait_for_segment(const std::string &segment_id, int timeout_ms)
             get_segment(segment_id, false, false);
             return true;
         }
-        catch (Non_existing_segment_exception)
+        catch (const Non_existing_segment_exception &)
         {
             usleep(5);
         }
@@ -104,7 +104,7 @@ SharedMemorySegment::SharedMemorySegment(std::string segment_id,
             segment_manager_ = boost::interprocess::managed_shared_memory(
                 boost::interprocess::open_only, segment_id.c_str());
         }
-        catch (boost::interprocess::interprocess_exception)
+        catch (const boost::interprocess::interprocess_exception &)
         {
             SEGMENT_SIZE_MUTEX.unlock();
             throw Non_existing_segment_exception(segment_id);

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -51,15 +51,14 @@ static inline void clear_memory()
                                                          true);
         shared_memory::LockedConditionVariable cond_var(
             shared_memory_test::segment_id, true);
-        
+
         // Mutex
         shared_memory::Mutex::clean(shared_memory_test::segment_mutex_id);
 
         // Condition variables
         shared_memory::ConditionVariable condition(
-                shared_memory_test::segment_cv_id, true);
+            shared_memory_test::segment_cv_id, true);
     }
-
 
     shared_memory::clear_shared_memory(shared_memory_test::segment_id);
 }
@@ -139,7 +138,7 @@ TEST_F(SharedMemoryTests, non_existing_segment_exception)
                                    value,
                                    false);
     }
-    catch (shared_memory::Non_existing_segment_exception)
+    catch (const shared_memory::Non_existing_segment_exception &)
     {
         thrown = true;
     }
@@ -675,7 +674,7 @@ TEST_F(SharedMemoryTests, exchange_manager)
                     id++;
                     waited = 0;
                 }
-                catch (shared_memory::Memory_overflow_exception)
+                catch (const shared_memory::Memory_overflow_exception &)
                 {
                     usleep(200);
                     waited += 200;
@@ -794,7 +793,7 @@ TEST_F(SharedMemoryTests, serialization2)
     {
         shared_memory::Item<10> in(v);
         shared_memory::Item<10> out;
-        const std::string& s = serializer.serialize(in);
+        const std::string &s = serializer.serialize(in);
         serializer.deserialize(s, out);
         ASSERT_EQ(in.get(), out.get());
     }


### PR DESCRIPTION
## Description

Catch exceptions by const reference.  This fixes the "catching polymorphic type ‘X’ by value" warnings.

Also some minor formatting changes in unit_tests.cpp due to running clang-format.


## How I Tested

Just ran the unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
