### PR TITLE
Bump version to 2.1.0 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+The format of this changelog is based on 
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+
+## [Unreleased]
+
+## [2.1.0] - 2022-06-29
+### Added
+- Python wrappers for functions `set_long_int`, `get_long_int` and
+  `delete_all_segments`.
+
+### Changed
+- Renamed `delete_all_segment()` to `delete_all_segments()` (an alias with with
+  the old name is kept for now).
+
+### Deprecated
+- `delete_all_segment()`: Use `delete_all_segments()` instead.
+
+
+## [2.0.0] - 2021-03-02
+
+There is no changelog for this or earlier versions.
+
+
+[Unreleased]: https://github.com/machines-in-motion/shared_memory/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/machines-in-motion/shared_memory/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/machines-in-motion/shared_memory/releases/tag/v2.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 cmake_minimum_required(VERSION 3.10.2)
 
-project(shared_memory VERSION 2.0.0)
+project(shared_memory VERSION 2.1.0)
 
 # Using C++17
 if(NOT CMAKE_C_STANDARD)


### PR DESCRIPTION
Bump version to 2.1.0 and add a changelog (following the format suggested by https://keepachangelog.com/en/1.0.0/).

In preparation for the upcoming Real Robot Challenge 2022, I'm making versioned releases of our packages and use the occasion to add proper changelog files.